### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rdlabo/capacitor-codescanner",
+  "private": false,
   "version": "8.0.3",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.