### PR TITLE
ci: cache demo .angular build cache (node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,8 +1,9 @@
 name: validation
 on:
-  push:
-    branches: [main]
   pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  push:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,9 +16,17 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: '**/package-lock.json'
+      - name: Cache Angular
+        uses: actions/cache@v5
+        with:
+          path: demo/angular/.angular/cache
+          key: ${{ runner.os }}-angular-${{ hashFiles('demo/angular/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-angular-${{ hashFiles('demo/angular/package-lock.json') }}-
+            ${{ runner.os }}-angular-
       - run: npm install
       - run: npm run build
       - run: npm install && npm run test:ci


### PR DESCRIPTION
## Summary
Speed up the demo CI by caching the Angular build cache.

## Changes
- Cache the demo's `.angular/cache` (Angular build cache) via `actions/cache`
- Unify `node-version` to 24

## Effect
Subsequent runs restore the Angular build cache, shortening the demo build/test.
